### PR TITLE
Rewrite music control based on working code

### DIFF
--- a/custom_components/polyvoice/conversation.py
+++ b/custom_components/polyvoice/conversation.py
@@ -2830,156 +2830,92 @@ class LMStudioConversationEntity(ConversationEntity):
             action = arguments.get("action", "").lower()
             query = arguments.get("query", "")
             media_type = arguments.get("media_type", "artist")
-            room = arguments.get("room", "").lower()
+            room = arguments.get("room", "living room").lower()  # Default to living room
             shuffle = arguments.get("shuffle", False)
 
-            # Use configured music players list
-            configured_players = self.music_players if self.music_players else []
+            # Use configured players from PolyVoice settings
+            all_players = self.music_players if self.music_players else []
+            default_player = self.default_music_player if self.default_music_player else (all_players[0] if all_players else None)
+            last_active_helper = self.last_active_speaker if self.last_active_speaker else None
 
-            # DYNAMIC: Find ALL media players in HA (for finding what's currently playing)
-            def get_all_media_players() -> list[str]:
-                """Get all media_player entities from Home Assistant."""
-                players = []
-                for entity_id in self.hass.states.async_entity_ids("media_player"):
-                    players.append(entity_id)
-                return players
+            if not all_players:
+                return {"error": "No music players configured. Go to Settings → PolyVoice → Configure and add your speakers."}
 
-            # Helper to check if entity is a valid speaker (not TV, receiver, etc.)
-            def is_valid_speaker(entity_id: str) -> bool:
-                """Check if entity is a speaker we can control."""
-                e = entity_id.lower()
-                # Valid: HA Voice satellites, Music Assistant players
-                if "home_assistant_voice" in e and "media_player" in e:
-                    return True
-                if "mass_" in e:
-                    return True
-                # Invalid: TVs, receivers, AirPlay, Chromecast built-in
-                invalid_keywords = ["_tv", "chromecast", "airplay", "vsx", "pioneer", "receiver", "zone_"]
-                for kw in invalid_keywords:
-                    if kw in e:
-                        return False
-                return False  # Default to invalid for safety
-
-            # DYNAMIC: Find currently playing player - PREFER valid speakers
-            def find_playing_player() -> str | None:
-                """Find any valid speaker that is currently playing."""
-                playing_players = []
-
-                # Collect ALL playing players that are valid speakers
-                for entity_id in self.hass.states.async_entity_ids("media_player"):
-                    state = self.hass.states.get(entity_id)
-                    if state and state.state in ("playing", "buffering"):
-                        if is_valid_speaker(entity_id):
-                            playing_players.append(entity_id)
-
-                if not playing_players:
-                    return None
-
-                _LOGGER.info("Found %d valid playing speakers: %s", len(playing_players), playing_players)
-                return playing_players[0]
-
-            # For targeting, prefer configured players; for finding what's playing, search all
-            all_players = configured_players if configured_players else get_all_media_players()
-
-            if not all_players and not self.default_music_player:
-                return {"error": "No music players found. Add them in Settings → PolyVoice → Entity Configuration."}
-
-            # Helper to find player by room name - ONLY valid speakers
-            def find_player_by_room(room_name: str) -> str | None:
-                room_normalized = room_name.replace(" ", "_").lower()
-
-                # Get only valid speakers
-                valid_speakers = [p for p in get_all_media_players() if is_valid_speaker(p)]
-
-                if not valid_speakers:
-                    _LOGGER.warning("No valid speakers found in HA!")
-                    return None
-
-                _LOGGER.info("Available speakers: %s", valid_speakers)
-
-                # Find matching player by room name
-                for player in valid_speakers:
-                    player_lower = player.lower()
-                    # Clean up entity name for matching
-                    player_name = player_lower.replace("media_player.", "")
-                    player_name = player_name.replace("home_assistant_voice_", "")
-                    player_name = player_name.replace("mass_", "")
-                    player_name = player_name.replace("_media_player", "")
-
-                    if room_normalized in player_name or room_name.replace(" ", "") in player_name:
-                        _LOGGER.info("Matched room '%s' to speaker: %s", room_name, player)
-                        return player
-
-                _LOGGER.warning("No speaker found for room '%s'. Available: %s", room_name, valid_speakers)
-                return None
-
-            # Helper to extract room name from entity_id
-            def get_room_from_player(player: str) -> str:
-                # media_player.home_assistant_voice_kitchen_media_player -> "Kitchen"
-                name = player.replace("media_player.", "")
+            # Build room -> player mapping from configured entity IDs
+            def extract_room_name(entity_id: str) -> str:
+                """Extract room name from entity_id for matching."""
+                name = entity_id.lower().replace("media_player.", "")
+                # Remove common prefixes/suffixes to get room name
                 name = name.replace("home_assistant_voice_", "")
                 name = name.replace("_media_player", "")
-                name = name.replace("mass_", "")
                 name = name.replace("_speaker", "")
-                name = name.replace("_", " ")
-                return name.title()
+                name = name.replace("_chromecast", "")
+                # Handle specific known mappings
+                if "pioneer" in name or "vsx" in name:
+                    name = "living room"
+                name = name.replace("_", " ").strip()
+                return name
+
+            # Create room name -> player entity mapping
+            music_players = {}
+            for player in all_players:
+                room_name = extract_room_name(player)
+                music_players[room_name] = player
+
+            _LOGGER.info("Music players: %s", music_players)
 
             try:
                 _LOGGER.info("Music control: action=%s, query=%s, media_type=%s, room=%s, shuffle=%s",
                             action, query, media_type, room, shuffle)
-                _LOGGER.info("Configured players: %s, default: %s", configured_players, self.default_music_player)
-
-                # Log what's currently playing across ALL players
-                playing_now = find_playing_player()
-                _LOGGER.info("Currently playing player: %s", playing_now)
 
                 # Determine target player(s)
                 if room == "everywhere":
-                    target_players = all_players if all_players else [self.default_music_player]
-                elif room:
-                    matched_player = find_player_by_room(room)
-                    if matched_player:
-                        target_players = [matched_player]
-                    else:
-                        target_players = [self.default_music_player] if self.default_music_player else all_players[:1]
+                    target_players = all_players
+                elif room in music_players:
+                    target_players = [music_players[room]]
                 else:
-                    # No room specified - use default or first available
-                    target_players = [self.default_music_player] if self.default_music_player else all_players[:1]
+                    # Try partial match
+                    matched = None
+                    for rname, player in music_players.items():
+                        if room in rname or rname in room:
+                            matched = player
+                            break
+                    target_players = [matched] if matched else [default_player]
 
                 if not target_players or not target_players[0]:
                     return {"error": "No music player available"}
-                
+
                 if action == "play":
                     if not query:
                         return {"error": "No music query specified. What would you like to play?"}
-                    
+
+                    # Enable radio_mode ONLY for genre queries
+                    use_radio_mode = (media_type == "genre")
+
                     # Determine the actual media_type for MA
                     if media_type == "genre":
                         ma_media_type = "playlist"
                     else:
                         ma_media_type = media_type
-                    
+
                     for player in target_players:
                         # Play media via Music Assistant
-                        # MINIMAL params - just like the original working YAML!
                         play_data = {
                             "media_id": query,
                             "media_type": ma_media_type,
+                            "enqueue": "replace",
                         }
-                        
+
                         _LOGGER.info("Calling music_assistant.play_media: %s on %s", play_data, player)
-                        
+
                         await self.hass.services.async_call(
                             "music_assistant", "play_media",
                             play_data,
                             target={"entity_id": player},
                             blocking=True
                         )
-                        
-                        # 1 second delay like the original YAML
-                        await asyncio.sleep(1)
-                        
-                        # Set shuffle AFTER play_media
+
+                        # Set shuffle AFTER play_media (like the working YAML script)
                         if shuffle or media_type == "genre":
                             await self.hass.services.async_call(
                                 "media_player", "shuffle_set",
@@ -2987,240 +2923,174 @@ class LMStudioConversationEntity(ConversationEntity):
                                 blocking=True
                             )
                             _LOGGER.info("Shuffle enabled for %s", player)
-                        
-                        _LOGGER.info("Playing '%s' on %s (shuffle=%s)", query, player, shuffle)
-                    
+
                     # Update last active player
-                    if self.last_active_speaker and self.hass.states.get(self.last_active_speaker):
+                    if last_active_helper and self.hass.states.get(last_active_helper):
                         await self.hass.services.async_call(
                             "input_text", "set_value",
-                            {"entity_id": self.last_active_speaker, "value": target_players[0]},
+                            {"entity_id": last_active_helper, "value": target_players[0]},
                             blocking=True
                         )
-                    
+
                     shuffle_text = "Shuffling" if shuffle else "Playing"
                     room_text = "everywhere" if room == "everywhere" else f"in the {room}"
                     return {"status": "playing", "message": f"{shuffle_text} {query} {room_text}"}
-                
+
                 elif action == "pause":
-                    # Find ANY currently playing player in HA
-                    playing_player = find_playing_player()
-                    if playing_player:
+                    for player in target_players:
                         await self.hass.services.async_call(
                             "media_player", "media_pause",
-                            target={"entity_id": playing_player},
+                            {"entity_id": player},
                             blocking=True
                         )
-                        room_name = get_room_from_player(playing_player)
-                        return {"status": "paused", "message": f"Music paused in {room_name}"}
-                    else:
-                        return {"error": "No music is currently playing"}
+                    room_text = "everywhere" if room == "everywhere" else f"in the {room}"
+                    return {"status": "paused", "message": f"Music paused {room_text}"}
 
                 elif action == "resume":
-                    # Find any paused player across ALL media players
-                    paused_player = None
-                    for entity_id in self.hass.states.async_entity_ids("media_player"):
-                        state = self.hass.states.get(entity_id)
-                        if state and state.state == "paused":
-                            paused_player = entity_id
-                            break
+                    # If default room, try last active or find paused player
+                    if room == "living room":
+                        if last_active_helper:
+                            last_state = self.hass.states.get(last_active_helper)
+                            if last_state and last_state.state not in ("unknown", "unavailable", ""):
+                                target_players = [last_state.state]
+                                _LOGGER.info("Resuming last active player: %s", target_players[0])
+                        # Find any paused player
+                        if not target_players or target_players[0] == default_player:
+                            for player in all_players:
+                                state = self.hass.states.get(player)
+                                if state and state.state == "paused":
+                                    target_players = [player]
+                                    break
 
-                    if paused_player:
+                    for player in target_players:
                         await self.hass.services.async_call(
                             "media_player", "media_play",
-                            target={"entity_id": paused_player},
+                            {"entity_id": player},
                             blocking=True
                         )
-                        room_name = get_room_from_player(paused_player)
-                        return {"status": "resumed", "message": f"Music resumed in {room_name}"}
-                    else:
-                        return {"error": "No paused music found to resume"}
+
+                    # Find room name for response
+                    resumed_room = "the last active speaker"
+                    for rname, pid in music_players.items():
+                        if pid == target_players[0]:
+                            resumed_room = f"the {rname}"
+                            break
+                    return {"status": "resumed", "message": f"Music resumed in {resumed_room}"}
 
                 elif action == "stop":
-                    # Find ANY currently playing player in HA
-                    playing_player = find_playing_player()
-                    if playing_player:
+                    for player in target_players:
                         await self.hass.services.async_call(
                             "media_player", "media_stop",
-                            target={"entity_id": playing_player},
+                            {"entity_id": player},
                             blocking=True
                         )
-                        room_name = get_room_from_player(playing_player)
-                        return {"status": "stopped", "message": f"Music stopped in {room_name}"}
-                    else:
-                        return {"error": "No music is currently playing"}
-                
-                elif action == "skip_next":
-                    # Find ANY currently playing player in HA
-                    playing_player = find_playing_player()
+                    room_text = "everywhere" if room == "everywhere" else f"in the {room}"
+                    return {"status": "stopped", "message": f"Music stopped {room_text}"}
 
-                    if playing_player:
-                        _LOGGER.info("skip_next: Found playing player: %s", playing_player)
+                elif action == "skip_next":
+                    for player in target_players:
                         await self.hass.services.async_call(
                             "media_player", "media_next_track",
-                            target={"entity_id": playing_player},
+                            {"entity_id": player},
                             blocking=True
                         )
-                        return {"status": "skipped", "message": "Skipped to next track"}
-                    else:
-                        _LOGGER.warning("skip_next: No playing player found in entire HA!")
-                        return {"error": "No music is currently playing"}
-                
-                elif action == "skip_previous":
-                    # Find ANY currently playing player in HA
-                    playing_player = find_playing_player()
+                    return {"status": "skipped", "message": "Skipped to next track"}
 
-                    if playing_player:
-                        _LOGGER.info("skip_previous: Found playing player: %s", playing_player)
+                elif action == "skip_previous":
+                    for player in target_players:
                         await self.hass.services.async_call(
                             "media_player", "media_previous_track",
-                            target={"entity_id": playing_player},
+                            {"entity_id": player},
                             blocking=True
                         )
-                        return {"status": "skipped", "message": "Skipped to previous track"}
-                    else:
-                        _LOGGER.warning("skip_previous: No playing player found in entire HA!")
-                        return {"error": "No music is currently playing"}
-                
+                    return {"status": "skipped", "message": "Skipped to previous track"}
+
                 elif action == "what_playing":
-                    # Find ANY currently playing player in HA
-                    playing_player = find_playing_player()
+                    # Find first playing player
+                    for player in all_players:
+                        state = self.hass.states.get(player)
+                        if state and state.state == "playing":
+                            attrs = state.attributes
+                            title = attrs.get("media_title", "Unknown")
+                            artist = attrs.get("media_artist", "Unknown")
+                            album = attrs.get("media_album_name", "")
 
-                    if playing_player:
-                        state = self.hass.states.get(playing_player)
-                        attrs = state.attributes
-                        title = attrs.get("media_title", "Unknown")
-                        artist = attrs.get("media_artist", "Unknown")
-                        album = attrs.get("media_album_name", "")
-                        room_name = get_room_from_player(playing_player)
+                            # Find room name
+                            room_name = "unknown room"
+                            for rname, pid in music_players.items():
+                                if pid == player:
+                                    room_name = rname
+                                    break
 
-                        result = {
-                            "title": title,
-                            "artist": artist,
-                            "room": room_name,
-                        }
-                        if album:
-                            result["album"] = album
-                        return result
+                            result = {
+                                "title": title,
+                                "artist": artist,
+                                "room": room_name,
+                            }
+                            if album:
+                                result["album"] = album
+                            return result
 
                     return {"message": "No music is currently playing"}
-                
+
                 elif action == "transfer":
-                    if not room:
-                        return {"error": "Please specify which room to transfer to (e.g., 'transfer to kitchen')"}
-
-                    # Find ANY currently playing player in HA (source)
-                    source_player = find_playing_player()
-
-                    # If nothing playing, check for paused across ALL players
-                    if not source_player:
-                        for entity_id in self.hass.states.async_entity_ids("media_player"):
-                            state = self.hass.states.get(entity_id)
-                            if state and state.state == "paused":
-                                source_player = entity_id
-                                _LOGGER.info("Found paused player for transfer: %s", entity_id)
-                                break
+                    # Find currently playing player
+                    source_player = None
+                    for player in all_players:
+                        state = self.hass.states.get(player)
+                        if state and state.state in ("playing", "paused"):
+                            source_player = player
+                            break
 
                     if not source_player:
                         return {"error": "No music is currently playing to transfer"}
 
-                    # Find target player by room name
-                    target_player = find_player_by_room(room)
-                    if not target_player:
-                        return {"error": f"Could not find a speaker in '{room}'. Available rooms: {', '.join([get_room_from_player(p) for p in all_players])}"}
+                    # Get target player
+                    target_player = target_players[0]
 
                     if source_player == target_player:
-                        return {"message": f"Music is already playing in {room}"}
+                        return {"message": f"Music is already playing in the {room}"}
 
-                    _LOGGER.info("Transferring music from %s to %s", source_player, target_player)
+                    _LOGGER.info("Transferring from %s to %s", source_player, target_player)
 
-                    # Get what's currently playing on source
-                    source_state = self.hass.states.get(source_player)
-                    if not source_state:
-                        return {"error": "Could not get source player state"}
-
-                    media_id = source_state.attributes.get("media_content_id")
-                    media_type = source_state.attributes.get("media_content_type", "music")
-
-                    if not media_id:
-                        return {"error": "Could not get current media to transfer"}
-
-                    _LOGGER.info("Transferring media_id=%s to %s", media_id, target_player)
-
-                    try:
-                        # Play the same media on target
-                        await self.hass.services.async_call(
-                            "media_player", "play_media",
-                            {
-                                "media_content_id": media_id,
-                                "media_content_type": media_type,
-                            },
-                            target={"entity_id": target_player},
-                            blocking=True
-                        )
-
-                        # Stop/pause source
-                        await self.hass.services.async_call(
-                            "media_player", "media_pause",
-                            target={"entity_id": source_player},
-                            blocking=True
-                        )
-                        _LOGGER.info("Transfer completed: %s -> %s", source_player, target_player)
-                    except Exception as transfer_err:
-                        _LOGGER.error("Transfer failed: %s", transfer_err)
-                        return {"error": f"Transfer failed: {str(transfer_err)}"}
+                    # Use Music Assistant transfer_queue (the working method!)
+                    await self.hass.services.async_call(
+                        "music_assistant", "transfer_queue",
+                        target={"entity_id": target_player},
+                        blocking=True
+                    )
 
                     # Update last active player
-                    if self.last_active_speaker and self.hass.states.get(self.last_active_speaker):
+                    if last_active_helper and self.hass.states.get(last_active_helper):
                         await self.hass.services.async_call(
                             "input_text", "set_value",
-                            {"entity_id": self.last_active_speaker, "value": target_player},
+                            {"entity_id": last_active_helper, "value": target_player},
                             blocking=True
                         )
 
-                    room_text = get_room_from_player(target_player)
-                    return {"status": "transferred", "message": f"Music transferred to {room_text}"}
+                    room_text = room if room != "living room" else "living room"
+                    return {"status": "transferred", "message": f"Music transferred to the {room_text}"}
 
                 elif action == "volume":
                     volume_level = arguments.get("volume")
                     if volume_level is None:
                         return {"error": "Please specify volume level (0-100)"}
 
-                    # Clamp volume to 0-100
                     volume_level = max(0, min(100, int(volume_level)))
                     volume_float = volume_level / 100.0
 
-                    # Find target: room-specific, or currently playing
-                    if room and room != "everywhere":
-                        target_player = find_player_by_room(room)
-                    else:
-                        # Find ANY currently playing/paused player in HA
-                        target_player = find_playing_player()
-                        if not target_player:
-                            # Check for paused
-                            for entity_id in self.hass.states.async_entity_ids("media_player"):
-                                state = self.hass.states.get(entity_id)
-                                if state and state.state == "paused":
-                                    target_player = entity_id
-                                    break
+                    for player in target_players:
+                        await self.hass.services.async_call(
+                            "media_player", "volume_set",
+                            {"entity_id": player, "volume_level": volume_float},
+                            blocking=True
+                        )
 
-                    if not target_player:
-                        return {"error": "No speaker found to adjust volume"}
-
-                    await self.hass.services.async_call(
-                        "media_player", "volume_set",
-                        {"volume_level": volume_float},
-                        target={"entity_id": target_player},
-                        blocking=True
-                    )
-                    _LOGGER.info("Set volume to %d%% on %s", volume_level, target_player)
-
-                    room_name = get_room_from_player(target_player)
-                    return {"status": "volume_set", "message": f"Volume set to {volume_level}% in {room_name}"}
+                    return {"status": "volume_set", "message": f"Volume set to {volume_level}%"}
 
                 else:
                     return {"error": f"Unknown action: {action}"}
-                    
+
             except Exception as err:
                 _LOGGER.error("Error controlling music: %s", err, exc_info=True)
                 return {"error": f"Failed to control music: {str(err)}"}


### PR DESCRIPTION
- Uses configured players from UI (no hardcoding)
- Auto-extracts room names from entity IDs
- Uses music_assistant.transfer_queue for transfer (works!)
- Uses music_assistant.play_media for playing
- Simpler, more reliable room matching
- Pioneer/VSX entities auto-map to "living room"