### PR TITLE
Hybridize music control: native intents + LLM play/transfer

### DIFF
--- a/custom_components/polyvoice/const.py
+++ b/custom_components/polyvoice/const.py
@@ -220,12 +220,8 @@ DEFAULT_EXCLUDED_INTENTS: Final = [
     "HassClimateGetTemperature",
     "HassClimateSetTemperature",
     "HassTimerStatus",
-    # Music intents - route to PolyVoice for Music Assistant control
-    "HassMediaNext",
-    "HassMediaPause",
-    "HassMediaPrevious",
-    "HassMediaUnpause",
-    "HassSetVolume",
+    # Music intents (pause/resume/skip) now handled by native HA intents
+    # Only play/shuffle/transfer go to LLM via control_music tool
 ]
 DEFAULT_CUSTOM_EXCLUDED_INTENTS: Final = ""
 DEFAULT_ENABLE_ASSIST: Final = True


### PR DESCRIPTION
Changes:
- Removed HassMediaNext/Pause/Previous/Unpause from excluded intents so they're handled by native HA intents (no more double-skip!)
- Simplified control_music tool to ONLY handle: play, transfer
- Fixed transfer_queue to use correct format with auto_play: True
- Shuffle now: enables shuffle FIRST, plays, then skips to fresh order
- Room matching uses friendly_name attribute (Kitchen, not 09ce7c)

Native HA now handles: pause, resume, next, previous, volume
LLM tool handles: play, shuffle, transfer