### PR TITLE
Remove conversation memory feature entirely - fully stateless

### DIFF
--- a/custom_components/polyvoice/config_flow.py
+++ b/custom_components/polyvoice/config_flow.py
@@ -76,9 +76,6 @@ from .const import (
     CONF_DEVICE_ALIASES,
     CONF_NOTIFICATION_SERVICE,
     CONF_CAMERA_ENTITIES,
-    # Conversation settings
-    CONF_CONVERSATION_MEMORY,
-    CONF_MEMORY_MAX_MESSAGES,
     # Defaults
     DEFAULT_USE_NATIVE_INTENTS,
     DEFAULT_EXCLUDED_INTENTS,
@@ -111,8 +108,6 @@ from .const import (
     DEFAULT_DEVICE_ALIASES,
     DEFAULT_NOTIFICATION_SERVICE,
     DEFAULT_CAMERA_ENTITIES,
-    DEFAULT_CONVERSATION_MEMORY,
-    DEFAULT_MEMORY_MAX_MESSAGES,
     ALL_NATIVE_INTENTS,
 )
 
@@ -733,9 +728,6 @@ class LMStudioOptionsFlowHandler(config_entries.OptionsFlow):
     ) -> FlowResult:
         """Handle advanced settings."""
         if user_input is not None:
-            # Explicitly handle boolean - unchecked checkbox may not be in user_input
-            if CONF_CONVERSATION_MEMORY not in user_input:
-                user_input[CONF_CONVERSATION_MEMORY] = False
             new_options = {**self._entry.options, **user_input}
             return self.async_create_entry(title="", data=new_options)
 
@@ -745,14 +737,6 @@ class LMStudioOptionsFlowHandler(config_entries.OptionsFlow):
             step_id="advanced",
             data_schema=vol.Schema(
                 {
-                    vol.Required(
-                        CONF_CONVERSATION_MEMORY,
-                        default=current.get(CONF_CONVERSATION_MEMORY, False),
-                    ): selector.BooleanSelector(),
-                    vol.Optional(
-                        CONF_MEMORY_MAX_MESSAGES,
-                        default=current.get(CONF_MEMORY_MAX_MESSAGES, DEFAULT_MEMORY_MAX_MESSAGES),
-                    ): vol.All(vol.Coerce(int), vol.Range(min=2, max=50)),
                     vol.Optional(
                         CONF_LLM_HASS_API,
                         default=current.get(CONF_LLM_HASS_API, DEFAULT_LLM_HASS_API),

--- a/custom_components/polyvoice/const.py
+++ b/custom_components/polyvoice/const.py
@@ -196,15 +196,6 @@ DEFAULT_NOTIFICATION_SERVICE: Final = ""
 DEFAULT_CAMERA_ENTITIES: Final = ""
 
 # =============================================================================
-# CONVERSATION SETTINGS
-# =============================================================================
-CONF_CONVERSATION_MEMORY: Final = "conversation_memory"
-CONF_MEMORY_MAX_MESSAGES: Final = "memory_max_messages"
-
-DEFAULT_CONVERSATION_MEMORY: Final = False  # Stateless by default
-DEFAULT_MEMORY_MAX_MESSAGES: Final = 10
-
-# =============================================================================
 # NATIVE INTENTS
 # =============================================================================
 CONF_USE_NATIVE_INTENTS: Final = "use_native_intents"

--- a/custom_components/polyvoice/conversation.py
+++ b/custom_components/polyvoice/conversation.py
@@ -83,9 +83,6 @@ from .const import (
     CONF_DEVICE_ALIASES,
     CONF_NOTIFICATION_SERVICE,
     CONF_CAMERA_ENTITIES,
-    # Conversation settings
-    CONF_CONVERSATION_MEMORY,
-    CONF_MEMORY_MAX_MESSAGES,
     # Defaults
     DEFAULT_EXCLUDED_INTENTS,
     DEFAULT_CUSTOM_EXCLUDED_INTENTS,
@@ -103,8 +100,6 @@ from .const import (
     DEFAULT_ENABLE_THERMOSTAT,
     DEFAULT_ENABLE_DEVICE_STATUS,
     DEFAULT_ENABLE_WIKIPEDIA,
-    DEFAULT_CONVERSATION_MEMORY,
-    DEFAULT_MEMORY_MAX_MESSAGES,
     CAMERA_FRIENDLY_NAMES,
     ALL_NATIVE_INTENTS,
 )
@@ -419,9 +414,6 @@ class LMStudioConversationEntity(ConversationEntity):
         # Tools cache (built once, reused for all requests)
         self._tools = None
 
-        # Conversation memory storage (keyed by conversation_id)
-        self._conversation_history: dict[str, list[dict]] = {}
-
         # Initialize config
         self._update_from_config({**config_entry.data, **config_entry.options})
 
@@ -565,10 +557,6 @@ class LMStudioConversationEntity(ConversationEntity):
                 camera_key.replace("_", " ").title()
             )
             self.camera_friendly_names[camera_key] = friendly_name
-
-        # Conversation memory settings
-        self.conversation_memory_enabled = config.get(CONF_CONVERSATION_MEMORY, DEFAULT_CONVERSATION_MEMORY)
-        self.memory_max_messages = config.get(CONF_MEMORY_MAX_MESSAGES, DEFAULT_MEMORY_MAX_MESSAGES)
 
         # Build tools list ONCE (major performance boost!)
         self._tools = self._build_tools()

--- a/custom_components/polyvoice/strings.json
+++ b/custom_components/polyvoice/strings.json
@@ -114,8 +114,6 @@
       "advanced": {
         "title": "Advanced Settings",
         "data": {
-          "conversation_memory": "Enable Conversation Memory",
-          "memory_max_messages": "Max Messages to Remember (2-50)",
           "llm_hass_api": "LLM Home Assistant API",
           "system_prompt": "System Prompt"
         }

--- a/custom_components/polyvoice/translations/en.json
+++ b/custom_components/polyvoice/translations/en.json
@@ -114,8 +114,6 @@
       "advanced": {
         "title": "Advanced Settings",
         "data": {
-          "conversation_memory": "Enable Conversation Memory",
-          "memory_max_messages": "Max Messages to Remember (2-50)",
           "llm_hass_api": "LLM Home Assistant API",
           "system_prompt": "System Prompt"
         }


### PR DESCRIPTION
Removed all memory-related code:
- Removed CONF_CONVERSATION_MEMORY and CONF_MEMORY_MAX_MESSAGES
- Removed memory toggle and max messages from Advanced Settings UI
- Removed _conversation_history storage
- Removed memory-related imports from all files
- Cleaned up strings.json and translations

PolyVoice is now fully stateless - each request is independent.