### PR TITLE
Move hardcoded entities to UI configuration

### DIFF
--- a/custom_components/polyvoice/config_flow.py
+++ b/custom_components/polyvoice/config_flow.py
@@ -76,6 +76,12 @@ from .const import (
     CONF_DEVICE_ALIASES,
     CONF_NOTIFICATION_SERVICE,
     CONF_CAMERA_ENTITIES,
+    # Thermostat settings
+    CONF_THERMOSTAT_MIN_TEMP,
+    CONF_THERMOSTAT_MAX_TEMP,
+    CONF_THERMOSTAT_TEMP_STEP,
+    # Event names
+    CONF_FACIAL_RECOGNITION_EVENT,
     # Defaults
     DEFAULT_USE_NATIVE_INTENTS,
     DEFAULT_EXCLUDED_INTENTS,
@@ -108,6 +114,12 @@ from .const import (
     DEFAULT_DEVICE_ALIASES,
     DEFAULT_NOTIFICATION_SERVICE,
     DEFAULT_CAMERA_ENTITIES,
+    # Thermostat defaults
+    DEFAULT_THERMOSTAT_MIN_TEMP,
+    DEFAULT_THERMOSTAT_MAX_TEMP,
+    DEFAULT_THERMOSTAT_TEMP_STEP,
+    # Event defaults
+    DEFAULT_FACIAL_RECOGNITION_EVENT,
     ALL_NATIVE_INTENTS,
 )
 
@@ -611,6 +623,50 @@ class LMStudioOptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_NOTIFICATION_SERVICE,
                         default=current.get(CONF_NOTIFICATION_SERVICE, DEFAULT_NOTIFICATION_SERVICE),
+                    ): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.TEXT,
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_THERMOSTAT_MIN_TEMP,
+                        default=current.get(CONF_THERMOSTAT_MIN_TEMP, DEFAULT_THERMOSTAT_MIN_TEMP),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=32,
+                            max=100,
+                            step=1,
+                            unit_of_measurement="°F",
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_THERMOSTAT_MAX_TEMP,
+                        default=current.get(CONF_THERMOSTAT_MAX_TEMP, DEFAULT_THERMOSTAT_MAX_TEMP),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=32,
+                            max=100,
+                            step=1,
+                            unit_of_measurement="°F",
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_THERMOSTAT_TEMP_STEP,
+                        default=current.get(CONF_THERMOSTAT_TEMP_STEP, DEFAULT_THERMOSTAT_TEMP_STEP),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=1,
+                            max=10,
+                            step=1,
+                            unit_of_measurement="°F",
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_FACIAL_RECOGNITION_EVENT,
+                        default=current.get(CONF_FACIAL_RECOGNITION_EVENT, DEFAULT_FACIAL_RECOGNITION_EVENT),
                     ): selector.TextSelector(
                         selector.TextSelectorConfig(
                             type=selector.TextSelectorType.TEXT,

--- a/custom_components/polyvoice/const.py
+++ b/custom_components/polyvoice/const.py
@@ -139,6 +139,14 @@ CONF_DEVICE_ALIASES: Final = "device_aliases"
 CONF_NOTIFICATION_SERVICE: Final = "notification_service"
 CONF_CAMERA_ENTITIES: Final = "camera_entities"
 
+# Thermostat settings - user-configurable temperature range and step
+CONF_THERMOSTAT_MIN_TEMP: Final = "thermostat_min_temp"
+CONF_THERMOSTAT_MAX_TEMP: Final = "thermostat_max_temp"
+CONF_THERMOSTAT_TEMP_STEP: Final = "thermostat_temp_step"
+
+# Event names - user-configurable
+CONF_FACIAL_RECOGNITION_EVENT: Final = "facial_recognition_event"
+
 # Default camera friendly names mapping (voice aliases -> display_name)
 # Supports multiple spellings/variations for voice commands
 # Users configure actual cameras via CONF_CAMERA_ENTITIES; ha_video_vision handles resolution
@@ -194,6 +202,14 @@ DEFAULT_LAST_ACTIVE_SPEAKER: Final = ""  # input_text helper entity_id
 DEFAULT_DEVICE_ALIASES: Final = ""
 DEFAULT_NOTIFICATION_SERVICE: Final = ""
 DEFAULT_CAMERA_ENTITIES: Final = ""
+
+# Thermostat defaults (Fahrenheit)
+DEFAULT_THERMOSTAT_MIN_TEMP: Final = 60
+DEFAULT_THERMOSTAT_MAX_TEMP: Final = 85
+DEFAULT_THERMOSTAT_TEMP_STEP: Final = 2
+
+# Event name defaults
+DEFAULT_FACIAL_RECOGNITION_EVENT: Final = "polyvoice_facial_recognition"
 
 # =============================================================================
 # NATIVE INTENTS

--- a/custom_components/polyvoice/strings.json
+++ b/custom_components/polyvoice/strings.json
@@ -80,7 +80,12 @@
           "camera_entities": "Cameras",
           "default_music_player": "Default Music Player",
           "music_players": "Music Players by Room (room:entity_id, one per line)",
-          "notification_service": "Notification Service (e.g., mobile_app_your_phone)"
+          "notification_service": "Notification Service (e.g., mobile_app_your_phone)",
+          "last_active_speaker": "Last Active Speaker Helper (input_text)",
+          "thermostat_min_temp": "Thermostat Minimum Temperature",
+          "thermostat_max_temp": "Thermostat Maximum Temperature",
+          "thermostat_temp_step": "Temperature Adjustment Step",
+          "facial_recognition_event": "Facial Recognition Event Name"
         }
       },
       "api_keys": {


### PR DESCRIPTION
- Add thermostat temperature settings (min/max/step) to UI config
- Add configurable facial recognition event name
- Replace hardcoded temperature range (60-85°F) with user settings
- Replace hardcoded temperature step (±2°F) with user setting
- Replace hardcoded event name with configurable value

These settings are now available in Entity Configuration options:
- Thermostat Min/Max Temperature (default: 60-85°F)
- Temperature Adjustment Step (default: 2°F)
- Facial Recognition Event Name (default: polyvoice_facial_recognition)