### PR TITLE
Add Fahrenheit/Celsius toggle for thermostat

### DIFF
--- a/custom_components/polyvoice/config_flow.py
+++ b/custom_components/polyvoice/config_flow.py
@@ -81,6 +81,7 @@ from .const import (
     CONF_THERMOSTAT_MIN_TEMP,
     CONF_THERMOSTAT_MAX_TEMP,
     CONF_THERMOSTAT_TEMP_STEP,
+    CONF_THERMOSTAT_USE_CELSIUS,
     # Event names
     CONF_FACIAL_RECOGNITION_EVENT,
     # Defaults
@@ -120,6 +121,7 @@ from .const import (
     DEFAULT_THERMOSTAT_MIN_TEMP,
     DEFAULT_THERMOSTAT_MAX_TEMP,
     DEFAULT_THERMOSTAT_TEMP_STEP,
+    DEFAULT_THERMOSTAT_USE_CELSIUS,
     # Event defaults
     DEFAULT_FACIAL_RECOGNITION_EVENT,
     ALL_NATIVE_INTENTS,
@@ -543,6 +545,8 @@ class LMStudioOptionsFlowHandler(config_entries.OptionsFlow):
                 processed_input[CONF_THERMOSTAT_MAX_TEMP] = user_input[CONF_THERMOSTAT_MAX_TEMP]
             if CONF_THERMOSTAT_TEMP_STEP in user_input:
                 processed_input[CONF_THERMOSTAT_TEMP_STEP] = user_input[CONF_THERMOSTAT_TEMP_STEP]
+            if CONF_THERMOSTAT_USE_CELSIUS in user_input:
+                processed_input[CONF_THERMOSTAT_USE_CELSIUS] = user_input[CONF_THERMOSTAT_USE_CELSIUS]
 
             # Handle facial recognition event name
             if CONF_FACIAL_RECOGNITION_EVENT in user_input:
@@ -593,6 +597,10 @@ class LMStudioOptionsFlowHandler(config_entries.OptionsFlow):
                             multiple=False,
                         )
                     ),
+                    vol.Optional(
+                        CONF_THERMOSTAT_USE_CELSIUS,
+                        default=current.get(CONF_THERMOSTAT_USE_CELSIUS, DEFAULT_THERMOSTAT_USE_CELSIUS),
+                    ): cv.boolean,
                     vol.Optional(
                         CONF_CALENDAR_ENTITIES,
                         default=current_calendars,

--- a/custom_components/polyvoice/const.py
+++ b/custom_components/polyvoice/const.py
@@ -144,6 +144,7 @@ CONF_CAMERA_ENTITIES: Final = "camera_entities"
 CONF_THERMOSTAT_MIN_TEMP: Final = "thermostat_min_temp"
 CONF_THERMOSTAT_MAX_TEMP: Final = "thermostat_max_temp"
 CONF_THERMOSTAT_TEMP_STEP: Final = "thermostat_temp_step"
+CONF_THERMOSTAT_USE_CELSIUS: Final = "thermostat_use_celsius"
 
 # Event names - user-configurable
 CONF_FACIAL_RECOGNITION_EVENT: Final = "facial_recognition_event"
@@ -205,10 +206,11 @@ DEFAULT_DEVICE_ALIASES: Final = ""
 DEFAULT_NOTIFICATION_SERVICE: Final = ""
 DEFAULT_CAMERA_ENTITIES: Final = ""
 
-# Thermostat defaults (Fahrenheit)
+# Thermostat defaults (Fahrenheit by default)
 DEFAULT_THERMOSTAT_MIN_TEMP: Final = 60
 DEFAULT_THERMOSTAT_MAX_TEMP: Final = 85
 DEFAULT_THERMOSTAT_TEMP_STEP: Final = 2
+DEFAULT_THERMOSTAT_USE_CELSIUS: Final = False
 
 # Event name defaults
 DEFAULT_FACIAL_RECOGNITION_EVENT: Final = "polyvoice_facial_recognition"

--- a/custom_components/polyvoice/strings.json
+++ b/custom_components/polyvoice/strings.json
@@ -76,6 +76,7 @@
         "description": "Configure which Home Assistant entities to use for each feature",
         "data": {
           "thermostat_entity": "Thermostat",
+          "thermostat_use_celsius": "Use Celsius (instead of Fahrenheit)",
           "calendar_entities": "Calendars",
           "camera_entities": "Cameras",
           "default_music_player": "Default Music Player",

--- a/custom_components/polyvoice/translations/en.json
+++ b/custom_components/polyvoice/translations/en.json
@@ -76,6 +76,7 @@
         "description": "Configure which Home Assistant entities to use for each feature",
         "data": {
           "thermostat_entity": "Thermostat",
+          "thermostat_use_celsius": "Use Celsius (instead of Fahrenheit)",
           "calendar_entities": "Calendars",
           "camera_entities": "Cameras",
           "default_music_player": "Default Music Player",


### PR DESCRIPTION
Users can now choose between Fahrenheit and Celsius for thermostat temperature display and control via a toggle in Entity Configuration. The setting affects tool descriptions, status responses, and device status checks.