### PR TITLE
Claude/add ncaa premier league s ih5 c

### DIFF
--- a/custom_components/polyvoice/conversation.py
+++ b/custom_components/polyvoice/conversation.py
@@ -2051,7 +2051,7 @@ class LMStudioConversationEntity(ConversationEntity):
                 url = None
                 full_name = team_name
                 for sport, league in leagues_to_try:
-                    teams_url = f"https://site.api.espn.com/apis/site/v2/sports/{sport}/{league}/teams"
+                    teams_url = f"https://site.api.espn.com/apis/site/v2/sports/{sport}/{league}/teams?limit=500"
                     async with self._session.get(teams_url, headers=headers) as teams_resp:
                         if teams_resp.status == 200:
                             teams_data = await teams_resp.json()


### PR DESCRIPTION
## Summary
- Add Premier League, NCAA Football, and NCAA Basketball to `leagues_to_try` for team lookups
- Add `limit=500` parameter to ESPN API calls to ensure all NCAA teams are discoverable
- Add Premier League team aliases (united, liverpool, arsenal, chelsea, spurs, tottenham)
- Update error messages and tool descriptions to reflect new supported leagues

## Test plan
- [ ] Ask about a Premier League team: "When is the next Liverpool game?"
- [ ] Ask about NCAA football: "Did Alabama win?"
- [ ] Ask about NCAA basketball: "Duke basketball score"
- [ ] Verify existing sports (NBA, NFL, MLB, NHL) still work
