### PR TITLE
Add gaming mode support for cloud fallback when gaming

### DIFF
--- a/custom_components/polyvoice/config_flow.py
+++ b/custom_components/polyvoice/config_flow.py
@@ -126,6 +126,16 @@ from .const import (
     # Event defaults
     DEFAULT_FACIAL_RECOGNITION_EVENT,
     ALL_NATIVE_INTENTS,
+    # Gaming mode
+    CONF_GAMING_MODE_ENTITY,
+    CONF_CLOUD_FALLBACK_PROVIDER,
+    CONF_CLOUD_FALLBACK_MODEL,
+    CONF_CLOUD_FALLBACK_API_KEY,
+    DEFAULT_GAMING_MODE_ENTITY,
+    DEFAULT_CLOUD_FALLBACK_PROVIDER,
+    DEFAULT_CLOUD_FALLBACK_MODEL,
+    DEFAULT_CLOUD_FALLBACK_API_KEY,
+    LOCAL_PROVIDERS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -336,6 +346,7 @@ class LMStudioOptionsFlowHandler(config_entries.OptionsFlow):
                 "api_keys": "API Keys",
                 "location": "Location Settings",
                 "intents": "Native Intents",
+                "gaming": "Gaming Mode (Cloud Fallback)",
                 "advanced": "Advanced Settings",
             },
         )
@@ -824,6 +835,60 @@ class LMStudioOptionsFlowHandler(config_entries.OptionsFlow):
                     ): str,
                 }
             ),
+        )
+
+    async def async_step_gaming(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle gaming mode (cloud fallback) settings."""
+        if user_input is not None:
+            new_options = {**self._entry.options, **user_input}
+            return self.async_create_entry(title="", data=new_options)
+
+        current = {**self._entry.data, **self._entry.options}
+
+        # Build cloud provider options (exclude local providers)
+        cloud_provider_options = [
+            selector.SelectOptionDict(value=p, label=PROVIDER_NAMES[p])
+            for p in ALL_PROVIDERS
+            if p not in LOCAL_PROVIDERS
+        ]
+
+        return self.async_show_form(
+            step_id="gaming",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_GAMING_MODE_ENTITY,
+                        default=current.get(CONF_GAMING_MODE_ENTITY, DEFAULT_GAMING_MODE_ENTITY),
+                    ): selector.EntitySelector(
+                        selector.EntitySelectorConfig(
+                            domain="input_boolean",
+                            multiple=False,
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_CLOUD_FALLBACK_PROVIDER,
+                        default=current.get(CONF_CLOUD_FALLBACK_PROVIDER, DEFAULT_CLOUD_FALLBACK_PROVIDER),
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=cloud_provider_options,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_CLOUD_FALLBACK_MODEL,
+                        default=current.get(CONF_CLOUD_FALLBACK_MODEL, DEFAULT_CLOUD_FALLBACK_MODEL),
+                    ): str,
+                    vol.Optional(
+                        CONF_CLOUD_FALLBACK_API_KEY,
+                        default=current.get(CONF_CLOUD_FALLBACK_API_KEY, DEFAULT_CLOUD_FALLBACK_API_KEY),
+                    ): str,
+                }
+            ),
+            description_placeholders={
+                "gaming_note": "When gaming mode is ON and your default provider is local (LM Studio/Ollama), PolyVoice will automatically switch to the cloud fallback provider.",
+            },
         )
 
     async def async_step_advanced(

--- a/custom_components/polyvoice/const.py
+++ b/custom_components/polyvoice/const.py
@@ -309,3 +309,19 @@ DEFAULT_OPENWEATHERMAP_API_KEY: Final = ""
 DEFAULT_GOOGLE_PLACES_API_KEY: Final = ""
 DEFAULT_YELP_API_KEY: Final = ""
 DEFAULT_NEWSAPI_KEY: Final = ""
+
+# =============================================================================
+# GAMING MODE - Cloud Fallback Settings
+# =============================================================================
+CONF_GAMING_MODE_ENTITY: Final = "gaming_mode_entity"
+CONF_CLOUD_FALLBACK_PROVIDER: Final = "cloud_fallback_provider"
+CONF_CLOUD_FALLBACK_MODEL: Final = "cloud_fallback_model"
+CONF_CLOUD_FALLBACK_API_KEY: Final = "cloud_fallback_api_key"
+
+DEFAULT_GAMING_MODE_ENTITY: Final = "input_boolean.gaming_mode"
+DEFAULT_CLOUD_FALLBACK_PROVIDER: Final = PROVIDER_OPENROUTER
+DEFAULT_CLOUD_FALLBACK_MODEL: Final = "nvidia/nemotron-nano:free"
+DEFAULT_CLOUD_FALLBACK_API_KEY: Final = ""
+
+# Local providers that should switch to cloud when gaming mode is on
+LOCAL_PROVIDERS: Final = [PROVIDER_LM_STUDIO, PROVIDER_OLLAMA]


### PR DESCRIPTION
When gaming mode (input_boolean.gaming_mode) is ON and the default provider is local (LM Studio or Ollama), PolyVoice automatically switches to the configured cloud fallback provider (default: OpenRouter with nvidia/nemotron-nano:free model).

Changes:
- const.py: Add gaming mode constants and configuration keys
- config_flow.py: Add Gaming Mode section to options menu with entity selector, cloud provider dropdown, model, and API key fields
- conversation.py: Add runtime provider switching logic that checks gaming mode entity state and uses cloud fallback client when active