### PR TITLE
Add relative dates (Today/Yesterday/Tomorrow) to sports schedules

### DIFF
--- a/custom_components/polyvoice/conversation.py
+++ b/custom_components/polyvoice/conversation.py
@@ -828,7 +828,7 @@ class LMStudioConversationEntity(ConversationEntity):
 
             elif tool_name == "get_ufc_info":
                 return await sports_tool.get_ufc_info(
-                    arguments, self._session, self._track_api_call
+                    arguments, self._session, hass_tz, self._track_api_call
                 )
 
             elif tool_name == "get_stock_price":


### PR DESCRIPTION
- Last game now shows "Today", "Yesterday", or "Monday, January 6" format
- UFC events now show relative dates instead of just month/day/year
- Added hass_timezone parameter to get_ufc_info for proper date conversion