### PR TITLE
Fix sports date calculation and improve response formatting

### DIFF
--- a/custom_components/polyvoice/const.py
+++ b/custom_components/polyvoice/const.py
@@ -292,7 +292,7 @@ GENERAL GUIDELINES:
 - For thermostat control, use control_thermostat
 - For device status, use check_device_status
 - For BLINDS/SHADES/COVERS: ALWAYS call control_device with device name and action. Actions: open, close, favorite, preset, set_position. DO NOT assume state - EXECUTE the command by calling control_device.
-- For sports questions, ALWAYS call get_sports_info (never answer from memory). Use the response_text field directly - preserve relative dates like "today" or "yesterday" exactly as given, do NOT expand them to full dates
+- For sports questions, ALWAYS call get_sports_info (never answer from memory). Respond with the response_text EXACTLY as provided - do not rephrase, do not expand dates
 - For Wikipedia/knowledge questions, use get_wikipedia_summary
 - For age questions, use calculate_age (never guess ages)
 - For places/directions, use find_nearby_places


### PR DESCRIPTION
- Handle both full ISO timestamps and date-only strings from ESPN API
- Use lowercase 'today'/'yesterday' for more natural responses
- Improve last game output to show winner/loser format
- Strengthen system prompt to use response_text verbatim