### PR TITLE
Fix HACS update service call - use correct service name

### DIFF
--- a/custom_components/polyvoice/manifest.json
+++ b/custom_components/polyvoice/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/polyvoice/issues",
   "iot_class": "cloud_polling",
   "requirements": ["openai>=1.0.0"],
-  "version": "3.2.0"
+  "version": "3.2.1"
 }

--- a/custom_components/polyvoice/update.py
+++ b/custom_components/polyvoice/update.py
@@ -131,13 +131,12 @@ class PolyVoiceUpdateEntity(UpdateEntity):
         """Install the update via HACS."""
         # Trigger HACS update if available
         try:
-            # Try to call HACS update service
+            # Try to call HACS download service
             await self.hass.services.async_call(
                 "hacs",
-                "repository_download",
+                "download",
                 {
                     "repository": GITHUB_REPO,
-                    "category": "integration",
                 },
                 blocking=True,
             )


### PR DESCRIPTION
The update entity was calling non-existent hacs.repository_download service, which caused silent failures when users clicked "Install". Changed to the correct hacs.download service.

Bumped version to 3.2.1