### PR TITLE
Fix device registry version sync after updates

### DIFF
--- a/custom_components/polyvoice/manifest.json
+++ b/custom_components/polyvoice/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/polyvoice/issues",
   "iot_class": "cloud_polling",
   "requirements": ["openai>=1.0.0"],
-  "version": "3.2.1"
+  "version": "3.2.2"
 }


### PR DESCRIPTION
Added async_added_to_hass method that forces the device registry to update sw_version when the integration loads. This prevents the version from getting stuck after HACS updates.

Bumped version to 3.2.2