### PR TITLE
Fix version not updating - read from manifest.json fresh each time

### DIFF
--- a/custom_components/polyvoice/const.py
+++ b/custom_components/polyvoice/const.py
@@ -1,7 +1,19 @@
 """Constants for PolyVoice."""
+import json
+from pathlib import Path
 from typing import Final
 
 DOMAIN: Final = "polyvoice"
+
+
+def get_version() -> str:
+    """Get version from manifest.json - reads fresh each time."""
+    try:
+        manifest_path = Path(__file__).parent / "manifest.json"
+        with open(manifest_path) as f:
+            return json.load(f).get("version", "unknown")
+    except Exception:
+        return "unknown"
 
 # =============================================================================
 # LLM PROVIDER SETTINGS

--- a/custom_components/polyvoice/conversation.py
+++ b/custom_components/polyvoice/conversation.py
@@ -92,6 +92,7 @@ from .const import (
     PROVIDER_AZURE,
     PROVIDER_BASE_URLS,
     PROVIDER_GOOGLE,
+    get_version,
 )
 
 # Import from new modules
@@ -191,8 +192,9 @@ class LMStudioConversationEntity(ConversationEntity):
             "identifiers": {(DOMAIN, self.entry.entry_id)},
             "name": self.entry.title,
             "manufacturer": "LosCV29",
-            "model": "PolyVoice",
+            "model": "Voice Assistant",
             "entry_type": "service",
+            "sw_version": get_version(),
         }
 
     def _update_from_config(self, config: dict[str, Any]) -> None:

--- a/custom_components/polyvoice/manifest.json
+++ b/custom_components/polyvoice/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/polyvoice/issues",
   "iot_class": "cloud_polling",
   "requirements": ["openai>=1.0.0"],
-  "version": "3.2.2"
+  "version": "3.2.3"
 }


### PR DESCRIPTION
Root cause: conversation.py creates device FIRST without sw_version, then version gets stuck. Also module-level caching prevented updates.

Changes:
- Added get_version() function to const.py that reads manifest.json fresh
- Both conversation.py and update.py now use get_version()
- Removed module-level _INSTALLED_VERSION caching in update.py
- conversation.py now includes sw_version in device_info

Bumped version to 3.2.3