### PR TITLE
Fix blocking open() call in async context - v3.3.3

### DIFF
--- a/custom_components/polyvoice/const.py
+++ b/custom_components/polyvoice/const.py
@@ -5,15 +5,22 @@ from typing import Final
 
 DOMAIN: Final = "polyvoice"
 
-
-def get_version() -> str:
-    """Get version from manifest.json - reads fresh each time."""
+# Cache version at module load time to avoid blocking calls in async context
+def _load_version() -> str:
+    """Load version from manifest.json once at startup."""
     try:
         manifest_path = Path(__file__).parent / "manifest.json"
         with open(manifest_path) as f:
             return json.load(f).get("version", "unknown")
     except Exception:
         return "unknown"
+
+VERSION: Final = _load_version()
+
+
+def get_version() -> str:
+    """Get cached version."""
+    return VERSION
 
 # =============================================================================
 # LLM PROVIDER SETTINGS

--- a/custom_components/polyvoice/manifest.json
+++ b/custom_components/polyvoice/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/polyvoice/issues",
   "iot_class": "cloud_polling",
   "requirements": ["openai>=1.0.0"],
-  "version": "3.3.2"
+  "version": "3.3.3"
 }


### PR DESCRIPTION
Cache version at module load time instead of reading manifest.json on every get_version() call. Fixes HA event loop blocking error.