### PR TITLE
Add entity-based intent interception for Smart Devices - v3.3.5

### DIFF
--- a/custom_components/polyvoice/conversation.py
+++ b/custom_components/polyvoice/conversation.py
@@ -326,12 +326,13 @@ class LMStudioConversationEntity(ConversationEntity):
         if self.enable_music and self.room_player_mapping:
             self._music_controller = MusicController(self.hass, self.room_player_mapping)
 
-        # Register intent handlers
-        if self.excluded_intents:
+        # Register intent handlers for excluded intents AND/OR entity-based control
+        if self.excluded_intents or self.llm_controlled_entities:
             self._original_intent_handlers = register_intent_handlers(
                 self.hass,
                 self.entity_id,
                 self.excluded_intents,
+                self.llm_controlled_entities,
             )
 
         # Listen for config updates

--- a/custom_components/polyvoice/manifest.json
+++ b/custom_components/polyvoice/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/polyvoice/issues",
   "iot_class": "cloud_polling",
   "requirements": ["openai>=1.0.0"],
-  "version": "3.3.4"
+  "version": "3.3.5"
 }


### PR DESCRIPTION
Devices in the Smart Devices list now bypass native HA intents and route to the LLM, regardless of what intent type is triggered.

- Register handlers for ALL interceptable intents when Smart Devices exist
- Check target entity against llm_controlled_entities before deciding to intercept
- Fall back to native handler for non-matching entities