### PR TITLE
Use fuzzy_matching for Smart Device intent interception - v3.3.6

### DIFF
--- a/custom_components/polyvoice/manifest.json
+++ b/custom_components/polyvoice/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/polyvoice/issues",
   "iot_class": "cloud_polling",
   "requirements": ["openai>=1.0.0"],
-  "version": "3.3.5"
+  "version": "3.3.6"
 }


### PR DESCRIPTION
Now uses the same synonym-aware matching (blind/shade/curtain etc) that device control uses, so 'living room blinds' matches 'Living Room Shade' in Smart Devices list.