### PR TITLE
Add excluded_entities and expand interceptable intents - v3.3.7

### DIFF
--- a/custom_components/polyvoice/const.py
+++ b/custom_components/polyvoice/const.py
@@ -233,6 +233,7 @@ DEFAULT_THERMOSTAT_TEMP_STEP_CELSIUS: Final = 1
 # NATIVE INTENTS (with LLM fallback)
 # =============================================================================
 CONF_EXCLUDED_INTENTS: Final = "excluded_intents"
+CONF_EXCLUDED_ENTITIES: Final = "excluded_entities"
 
 DEFAULT_EXCLUDED_INTENTS: Final = [
     "HassGetState",           # Use check_device_status for richer responses

--- a/custom_components/polyvoice/conversation.py
+++ b/custom_components/polyvoice/conversation.py
@@ -44,6 +44,7 @@ from .const import (
     CONF_ENABLE_THERMOSTAT,
     CONF_ENABLE_WEATHER,
     CONF_ENABLE_WIKIPEDIA,
+    CONF_EXCLUDED_ENTITIES,
     CONF_EXCLUDED_INTENTS,
     CONF_GOOGLE_PLACES_API_KEY,
     CONF_LLM_CONTROLLED_ENTITIES,
@@ -260,6 +261,7 @@ class LMStudioConversationEntity(ConversationEntity):
         self.calendar_entities = parse_list_config(config.get(CONF_CALENDAR_ENTITIES, ""))
         self.camera_entities = parse_list_config(config.get(CONF_CAMERA_ENTITIES, ""))
         self.llm_controlled_entities = set(parse_list_config(config.get(CONF_LLM_CONTROLLED_ENTITIES, DEFAULT_LLM_CONTROLLED_ENTITIES)))
+        self.excluded_entities = set(parse_list_config(config.get(CONF_EXCLUDED_ENTITIES, "")))
         self.device_aliases = parse_entity_config(config.get(CONF_DEVICE_ALIASES, ""))
 
         # Thermostat settings
@@ -327,12 +329,13 @@ class LMStudioConversationEntity(ConversationEntity):
             self._music_controller = MusicController(self.hass, self.room_player_mapping)
 
         # Register intent handlers for excluded intents AND/OR entity-based control
-        if self.excluded_intents or self.llm_controlled_entities:
+        if self.excluded_intents or self.llm_controlled_entities or self.excluded_entities:
             self._original_intent_handlers = register_intent_handlers(
                 self.hass,
                 self.entity_id,
                 self.excluded_intents,
                 self.llm_controlled_entities,
+                self.excluded_entities,
             )
 
         # Listen for config updates

--- a/custom_components/polyvoice/manifest.json
+++ b/custom_components/polyvoice/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/polyvoice/issues",
   "iot_class": "cloud_polling",
   "requirements": ["openai>=1.0.0"],
-  "version": "3.3.6"
+  "version": "3.3.7"
 }

--- a/custom_components/polyvoice/strings.json
+++ b/custom_components/polyvoice/strings.json
@@ -90,7 +90,7 @@
         }
       },
       "smart_devices": {
-        "title": "Smart Devices",
+        "title": "Smart Devices (with Aliases)",
         "description": "{devices}",
         "data": {
           "action": "Action",
@@ -98,6 +98,15 @@
           "select_alias": "Select Alias",
           "new_entity": "New Device",
           "new_alias": "Voice Alias (what you'll say)"
+        }
+      },
+      "excluded_entities": {
+        "title": "LLM-Only Entities",
+        "description": "{entities}",
+        "data": {
+          "action": "Action",
+          "select_entity": "Select Entity to Remove",
+          "new_entity": "Add Entity (always routes to LLM)"
         }
       },
       "music_rooms": {

--- a/custom_components/polyvoice/translations/en.json
+++ b/custom_components/polyvoice/translations/en.json
@@ -88,7 +88,7 @@
         }
       },
       "smart_devices": {
-        "title": "Smart Devices",
+        "title": "Smart Devices (with Aliases)",
         "description": "{devices}",
         "data": {
           "action": "Action",
@@ -96,6 +96,15 @@
           "select_alias": "Select Alias",
           "new_entity": "New Device",
           "new_alias": "Voice Alias (what you'll say)"
+        }
+      },
+      "excluded_entities": {
+        "title": "LLM-Only Entities",
+        "description": "{entities}",
+        "data": {
+          "action": "Action",
+          "select_entity": "Select Entity to Remove",
+          "new_entity": "Add Entity (always routes to LLM)"
         }
       },
       "music_rooms": {


### PR DESCRIPTION
- Expanded INTERCEPTABLE_INTENTS to include ALL HA native intents (climate, timers, media, vacuum, lists, etc.) so users can exclude any intent type
- Added CONF_EXCLUDED_ENTITIES for entities that should ALWAYS route to LLM
- Added "LLM-Only Entities" UI in config flow for managing excluded_entities
- Fixed missing SLOT_PATTERNS in intent_handler.py
- Updated _should_intercept logic: excluded_intents OR excluded_entities OR llm_controlled_entities triggers LLM routing
- Expanded action_map for natural language command extraction