### PR TITLE
Simplify Smart Devices: use aliases for entity matching - v3.3.8

### DIFF
--- a/custom_components/polyvoice/config_flow.py
+++ b/custom_components/polyvoice/config_flow.py
@@ -72,7 +72,6 @@ from .const import (
     CONF_DEVICE_ALIASES,
     CONF_CAMERA_ENTITIES,
     CONF_LLM_CONTROLLED_ENTITIES,
-    CONF_EXCLUDED_ENTITIES,
     # Thermostat settings
     CONF_THERMOSTAT_MIN_TEMP,
     CONF_THERMOSTAT_MAX_TEMP,
@@ -433,8 +432,7 @@ class LMStudioOptionsFlowHandler(config_entries.OptionsFlow):
                 "model": "Model Settings",
                 "features": "Enable/Disable Features",
                 "entities": "PolyVoice Default Entities",
-                "smart_devices": "Smart Devices (with Aliases)",
-                "excluded_entities": "LLM-Only Entities",
+                "smart_devices": "Smart Devices",
                 "music_rooms": "Music Room Mapping",
                 "api_keys": "API Keys",
                 "location": "Location Settings",
@@ -962,96 +960,6 @@ class LMStudioOptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="smart_devices",
             description_placeholders={"devices": description},
-            data_schema=vol.Schema(schema_dict),
-        )
-
-    async def async_step_excluded_entities(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle LLM-only entities configuration.
-
-        These entities will ALWAYS be routed to the LLM, bypassing native
-        Home Assistant intents. Unlike Smart Devices, these don't have aliases.
-        """
-        current = {**self._entry.data, **self._entry.options}
-        current_excluded = current.get(CONF_EXCLUDED_ENTITIES, "")
-
-        # Parse current excluded entities
-        if isinstance(current_excluded, str) and current_excluded:
-            excluded_set = set(e.strip() for e in current_excluded.split("\n") if e.strip())
-        else:
-            excluded_set = set()
-
-        if user_input is not None:
-            action = user_input.get("action", "add")
-            selected_entity = user_input.get("select_entity", "")
-            new_entity = user_input.get("new_entity", "")
-
-            if action == "add" and new_entity:
-                excluded_set.add(new_entity)
-            elif action == "remove" and selected_entity:
-                excluded_set.discard(selected_entity)
-            elif not new_entity and not selected_entity:
-                # Empty submit - return to menu
-                return self.async_create_entry(title="", data=self._entry.options)
-
-            # Save updated config
-            updated_excluded = "\n".join(sorted(excluded_set)) if excluded_set else ""
-            new_options = {**self._entry.options, CONF_EXCLUDED_ENTITIES: updated_excluded}
-            self.hass.config_entries.async_update_entry(self._entry, options=new_options)
-
-            # Rebuild set for display
-            excluded_set = set(e.strip() for e in updated_excluded.split("\n") if e.strip()) if updated_excluded else set()
-
-        # Build display of current LLM-only entities
-        if excluded_set:
-            entity_lines = []
-            for eid in sorted(excluded_set):
-                state = self.hass.states.get(eid)
-                name = state.attributes.get("friendly_name", eid) if state else eid
-                entity_lines.append(f"• {name} ({eid})")
-            description = "\n".join(entity_lines)
-        else:
-            description = "No entities configured. Add entities that should always use the LLM."
-
-        # Build schema
-        schema_dict = {}
-
-        # Action selector
-        schema_dict[vol.Optional("action", default="add")] = selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=[
-                    selector.SelectOptionDict(value="add", label="Add Entity"),
-                    selector.SelectOptionDict(value="remove", label="Remove Entity"),
-                ],
-                mode=selector.SelectSelectorMode.DROPDOWN,
-            )
-        )
-
-        # Entity selector for removal (only show if we have entities)
-        if excluded_set:
-            entity_options = []
-            for eid in sorted(excluded_set):
-                state = self.hass.states.get(eid)
-                name = state.attributes.get("friendly_name", eid) if state else eid
-                entity_options.append(
-                    selector.SelectOptionDict(value=eid, label=f"{name}")
-                )
-            schema_dict[vol.Optional("select_entity")] = selector.SelectSelector(
-                selector.SelectSelectorConfig(
-                    options=entity_options,
-                    mode=selector.SelectSelectorMode.DROPDOWN,
-                )
-            )
-
-        # Entity selector for adding new
-        schema_dict[vol.Optional("new_entity")] = selector.EntitySelector(
-            selector.EntitySelectorConfig(multiple=False)
-        )
-
-        return self.async_show_form(
-            step_id="excluded_entities",
-            description_placeholders={"entities": description},
             data_schema=vol.Schema(schema_dict),
         )
 

--- a/custom_components/polyvoice/const.py
+++ b/custom_components/polyvoice/const.py
@@ -233,7 +233,6 @@ DEFAULT_THERMOSTAT_TEMP_STEP_CELSIUS: Final = 1
 # NATIVE INTENTS (with LLM fallback)
 # =============================================================================
 CONF_EXCLUDED_INTENTS: Final = "excluded_intents"
-CONF_EXCLUDED_ENTITIES: Final = "excluded_entities"
 
 DEFAULT_EXCLUDED_INTENTS: Final = [
     "HassGetState",           # Use check_device_status for richer responses

--- a/custom_components/polyvoice/conversation.py
+++ b/custom_components/polyvoice/conversation.py
@@ -44,7 +44,6 @@ from .const import (
     CONF_ENABLE_THERMOSTAT,
     CONF_ENABLE_WEATHER,
     CONF_ENABLE_WIKIPEDIA,
-    CONF_EXCLUDED_ENTITIES,
     CONF_EXCLUDED_INTENTS,
     CONF_GOOGLE_PLACES_API_KEY,
     CONF_LLM_CONTROLLED_ENTITIES,
@@ -261,7 +260,6 @@ class LMStudioConversationEntity(ConversationEntity):
         self.calendar_entities = parse_list_config(config.get(CONF_CALENDAR_ENTITIES, ""))
         self.camera_entities = parse_list_config(config.get(CONF_CAMERA_ENTITIES, ""))
         self.llm_controlled_entities = set(parse_list_config(config.get(CONF_LLM_CONTROLLED_ENTITIES, DEFAULT_LLM_CONTROLLED_ENTITIES)))
-        self.excluded_entities = set(parse_list_config(config.get(CONF_EXCLUDED_ENTITIES, "")))
         self.device_aliases = parse_entity_config(config.get(CONF_DEVICE_ALIASES, ""))
 
         # Thermostat settings
@@ -328,14 +326,14 @@ class LMStudioConversationEntity(ConversationEntity):
         if self.enable_music and self.room_player_mapping:
             self._music_controller = MusicController(self.hass, self.room_player_mapping)
 
-        # Register intent handlers for excluded intents AND/OR entity-based control
-        if self.excluded_intents or self.llm_controlled_entities or self.excluded_entities:
+        # Register intent handlers for excluded intents AND/OR Smart Devices
+        if self.excluded_intents or self.llm_controlled_entities:
             self._original_intent_handlers = register_intent_handlers(
                 self.hass,
                 self.entity_id,
                 self.excluded_intents,
                 self.llm_controlled_entities,
-                self.excluded_entities,
+                self.device_aliases,
             )
 
         # Listen for config updates

--- a/custom_components/polyvoice/manifest.json
+++ b/custom_components/polyvoice/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/polyvoice/issues",
   "iot_class": "cloud_polling",
   "requirements": ["openai>=1.0.0"],
-  "version": "3.3.7"
+  "version": "3.3.8"
 }

--- a/custom_components/polyvoice/strings.json
+++ b/custom_components/polyvoice/strings.json
@@ -90,7 +90,7 @@
         }
       },
       "smart_devices": {
-        "title": "Smart Devices (with Aliases)",
+        "title": "Smart Devices",
         "description": "{devices}",
         "data": {
           "action": "Action",
@@ -98,15 +98,6 @@
           "select_alias": "Select Alias",
           "new_entity": "New Device",
           "new_alias": "Voice Alias (what you'll say)"
-        }
-      },
-      "excluded_entities": {
-        "title": "LLM-Only Entities",
-        "description": "{entities}",
-        "data": {
-          "action": "Action",
-          "select_entity": "Select Entity to Remove",
-          "new_entity": "Add Entity (always routes to LLM)"
         }
       },
       "music_rooms": {

--- a/custom_components/polyvoice/translations/en.json
+++ b/custom_components/polyvoice/translations/en.json
@@ -88,7 +88,7 @@
         }
       },
       "smart_devices": {
-        "title": "Smart Devices (with Aliases)",
+        "title": "Smart Devices",
         "description": "{devices}",
         "data": {
           "action": "Action",
@@ -96,15 +96,6 @@
           "select_alias": "Select Alias",
           "new_entity": "New Device",
           "new_alias": "Voice Alias (what you'll say)"
-        }
-      },
-      "excluded_entities": {
-        "title": "LLM-Only Entities",
-        "description": "{entities}",
-        "data": {
-          "action": "Action",
-          "select_entity": "Select Entity to Remove",
-          "new_entity": "Add Entity (always routes to LLM)"
         }
       },
       "music_rooms": {


### PR DESCRIPTION
- Removed redundant excluded_entities feature
- Smart Devices now uses device_aliases for fuzzy matching
- When user says an alias that points to a Smart Device, it routes to LLM
- Simplified interception logic:
  1. Intent type in excluded_intents → LLM
  2. Target matches Smart Device (by name OR alias) → LLM
  3. Otherwise → native HA
- Cleaned up UI (removed LLM-Only Entities menu)