### PR TITLE
Fix EntityComponent access for conversation entity - v3.3.11

### DIFF
--- a/custom_components/polyvoice/intent_handler.py
+++ b/custom_components/polyvoice/intent_handler.py
@@ -248,8 +248,11 @@ class PolyVoiceIntentHandler(IntentHandler):
         _LOGGER.info("PolyVoice processing command: '%s'", command)
 
         try:
-            # Get the conversation entity
-            entity = self._hass.data.get("conversation", {}).get("entities", {}).get(self._conversation_entity_id)
+            # Get the conversation entity via EntityComponent
+            entity_component = self._hass.data.get("conversation")
+            entity = None
+            if entity_component and hasattr(entity_component, "get_entity"):
+                entity = entity_component.get_entity(self._conversation_entity_id)
 
             if entity and hasattr(entity, "async_process_intercepted"):
                 # Use dedicated method for intercepted intents

--- a/custom_components/polyvoice/manifest.json
+++ b/custom_components/polyvoice/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/polyvoice/issues",
   "iot_class": "cloud_polling",
   "requirements": ["openai>=1.0.0"],
-  "version": "3.3.10"
+  "version": "3.3.11"
 }


### PR DESCRIPTION
- Fixed: hass.data["conversation"] is an EntityComponent, not a dict
- Use entity_component.get_entity() to retrieve PolyVoice entity
- Alias matching was already working, this fixes the routing step