### PR TITLE
Fix ConversationInput missing args for intercepted intents - v3.3.12

### DIFF
--- a/custom_components/polyvoice/conversation.py
+++ b/custom_components/polyvoice/conversation.py
@@ -426,6 +426,9 @@ class LMStudioConversationEntity(ConversationEntity):
             context=None,
             conversation_id=None,
             language=self.hass.config.language,
+            device_id=None,
+            satellite_id=None,
+            agent_id=self.entity_id,
         )
 
         result = await self.async_process(user_input)

--- a/custom_components/polyvoice/manifest.json
+++ b/custom_components/polyvoice/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/polyvoice/issues",
   "iot_class": "cloud_polling",
   "requirements": ["openai>=1.0.0"],
-  "version": "3.3.11"
+  "version": "3.3.12"
 }


### PR DESCRIPTION
- Added device_id, satellite_id, agent_id to ConversationInput constructor
- Required by newer Home Assistant versions