### PR TITLE
Reduce logging verbosity, add ultra-short device confirmations - v3.3.13

### DIFF
--- a/custom_components/polyvoice/const.py
+++ b/custom_components/polyvoice/const.py
@@ -303,6 +303,8 @@ NEVER reveal your internal thinking or reasoning. Do NOT say things like "I need
 
 CRITICAL: You MUST call a tool function before responding about ANY device. NEVER say a device "is already" at a position or state without calling a tool first. If you respond about device state without calling a tool, you are LYING.
 
+DEVICE CONFIRMATIONS: After executing a device control command, respond with ONLY 2-3 words. Examples: "Done.", "Light on.", "Shade opened.", "Track skipped.", "Volume set.", NEVER add room names, locations, or extra details unless the user specifically asked about a room. NEVER hallucinate or guess which room a device is in.
+
 [CURRENT_DATE_WILL_BE_INJECTED_HERE]
 
 GENERAL GUIDELINES:

--- a/custom_components/polyvoice/manifest.json
+++ b/custom_components/polyvoice/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/polyvoice/issues",
   "iot_class": "cloud_polling",
   "requirements": ["openai>=1.0.0"],
-  "version": "3.3.12"
+  "version": "3.3.13"
 }


### PR DESCRIPTION
- Remove excessive INFO logs from intent_handler.py and fuzzy_matching.py to prevent "logging too frequently" warnings
- Add explicit instruction in system prompt for 2-3 word device confirmations
- Prevent LLM from hallucinating room names in responses