### PR TITLE
Add smart timer finish announcements - v3.4.2

### DIFF
--- a/custom_components/polyvoice/__init__.py
+++ b/custom_components/polyvoice/__init__.py
@@ -6,13 +6,17 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, Event, callback
 
 from .const import DOMAIN
+from .tools.timer import get_registered_timer, unregister_timer
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.CONVERSATION, Platform.UPDATE]
+
+# Key for storing the timer listener unsub function
+TIMER_LISTENER_KEY = "timer_finished_listener"
 
 
 async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
@@ -24,22 +28,141 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old entry to current version."""
     _LOGGER.info("Migrating PolyVoice from version %s", entry.version)
-    
+
     if entry.version < 2:
         hass.config_entries.async_update_entry(entry, version=2)
         _LOGGER.info("Migration to version 2 successful")
-    
+
     return True
+
+
+@callback
+def _handle_timer_finished(hass: HomeAssistant, event: Event) -> None:
+    """Handle timer.finished event and announce via TTS."""
+    entity_id = event.data.get("entity_id")
+    if not entity_id:
+        return
+
+    # Check if this timer was started by PolyVoice
+    timer_info = get_registered_timer(hass, entity_id)
+    if not timer_info:
+        _LOGGER.debug("Timer %s finished but was not started by PolyVoice", entity_id)
+        return
+
+    timer_name = timer_info.get("name", "Timer")
+    announce_player = timer_info.get("announce_player")
+
+    _LOGGER.info("PolyVoice timer finished: %s -> announcing on %s",
+                 timer_name, announce_player or "default")
+
+    # Unregister the timer
+    unregister_timer(hass, entity_id)
+
+    # Create announcement message
+    if timer_name.lower() in ("timer", "kitchen timer", "general timer"):
+        message = "Your timer is done!"
+    else:
+        message = f"Your {timer_name} timer is done!"
+
+    # Try to announce via TTS
+    hass.async_create_task(_announce_timer_finished(hass, message, announce_player))
+
+
+async def _announce_timer_finished(
+    hass: HomeAssistant,
+    message: str,
+    target_player: str | None
+) -> None:
+    """Announce timer completion via TTS or notification."""
+    announced = False
+
+    # Try TTS first
+    if target_player and hass.services.has_service("tts", "speak"):
+        try:
+            # Get available TTS engines
+            tts_entities = [
+                s.entity_id for s in hass.states.async_all()
+                if s.entity_id.startswith("tts.")
+            ]
+
+            if tts_entities:
+                await hass.services.async_call(
+                    "tts", "speak",
+                    {
+                        "entity_id": tts_entities[0],
+                        "media_player_entity_id": target_player,
+                        "message": message,
+                    },
+                    blocking=False
+                )
+                announced = True
+                _LOGGER.debug("Announced timer via tts.speak on %s", target_player)
+        except Exception as err:
+            _LOGGER.warning("TTS speak failed: %s", err)
+
+    # Fallback: try media_player.play_media with TTS URL
+    if not announced and target_player and hass.services.has_service("tts", "google_translate_say"):
+        try:
+            await hass.services.async_call(
+                "tts", "google_translate_say",
+                {
+                    "entity_id": target_player,
+                    "message": message,
+                },
+                blocking=False
+            )
+            announced = True
+            _LOGGER.debug("Announced timer via google_translate_say on %s", target_player)
+        except Exception as err:
+            _LOGGER.debug("google_translate_say failed: %s", err)
+
+    # Fallback: try cloud say
+    if not announced and target_player and hass.services.has_service("tts", "cloud_say"):
+        try:
+            await hass.services.async_call(
+                "tts", "cloud_say",
+                {
+                    "entity_id": target_player,
+                    "message": message,
+                },
+                blocking=False
+            )
+            announced = True
+            _LOGGER.debug("Announced timer via cloud_say on %s", target_player)
+        except Exception as err:
+            _LOGGER.debug("cloud_say failed: %s", err)
+
+    # Last resort: persistent notification
+    if not announced:
+        await hass.services.async_call(
+            "persistent_notification", "create",
+            {
+                "title": "Timer Finished",
+                "message": message,
+                "notification_id": "polyvoice_timer",
+            },
+            blocking=False
+        )
+        _LOGGER.debug("Created persistent notification for timer (no TTS available)")
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up PolyVoice from a config entry."""
     hass.data.setdefault(DOMAIN, {})
-    
+
     config = {**entry.data, **entry.options}
     hass.data[DOMAIN][entry.entry_id] = {"config": config}
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Register timer.finished event listener (only once per HA instance)
+    if TIMER_LISTENER_KEY not in hass.data[DOMAIN]:
+        unsub = hass.bus.async_listen(
+            "timer.finished",
+            lambda event: _handle_timer_finished(hass, event)
+        )
+        hass.data[DOMAIN][TIMER_LISTENER_KEY] = unsub
+        _LOGGER.debug("Registered timer.finished event listener")
 
     entry.async_on_unload(
         entry.add_update_listener(_async_update_listener)
@@ -59,4 +182,15 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)
+
+        # Unsubscribe from timer events if this was the last entry
+        remaining_entries = [
+            e for e in hass.config_entries.async_entries(DOMAIN)
+            if e.entry_id != entry.entry_id
+        ]
+        if not remaining_entries and TIMER_LISTENER_KEY in hass.data[DOMAIN]:
+            unsub = hass.data[DOMAIN].pop(TIMER_LISTENER_KEY)
+            unsub()
+            _LOGGER.debug("Unregistered timer.finished event listener")
+
     return unload_ok

--- a/custom_components/polyvoice/conversation.py
+++ b/custom_components/polyvoice/conversation.py
@@ -933,7 +933,11 @@ class LMStudioConversationEntity(ConversationEntity):
                 return {"error": "Music control not configured"}
 
             elif tool_name == "control_timer":
-                return await timer_tool.control_timer(arguments, self.hass)
+                return await timer_tool.control_timer(
+                    arguments, self.hass,
+                    device_id=user_input.device_id,
+                    room_player_mapping=self.room_player_mapping
+                )
 
             elif tool_name == "manage_list":
                 return await lists_tool.manage_list(arguments, self.hass)

--- a/custom_components/polyvoice/manifest.json
+++ b/custom_components/polyvoice/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/polyvoice/issues",
   "iot_class": "cloud_polling",
   "requirements": ["openai>=1.0.0"],
-  "version": "3.4.1"
+  "version": "3.4.2"
 }


### PR DESCRIPTION
Timer completions now announce on the speaker that heard the original command:
- Tracks device_id from voice satellite to find target player
- Matches device name to room_player_mapping
- Falls back to first configured media player
- Uses tts.speak, google_translate_say, or cloud_say
- Falls back to persistent_notification if no TTS

Announcement logic:
- "Your timer is done!" for generic timers
- "Your pizza timer is done!" for named timers